### PR TITLE
Add Travis build status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# :earth_africa: fedora
+# :earth_africa: fedora [![Build Status](https://travis-ci.org/multiarch/fedora.svg?branch=master)](https://travis-ci.org/multiarch/fedora)
 
 ![](https://raw.githubusercontent.com/multiarch/dockerfile/master/logo.jpg)
 


### PR DESCRIPTION
This PR is just to add the Travis build status badge to README.
The modified README is aligned 
https://github.com/junaruga/fedora/tree/feature/readme-travis-badge
with otehr multiarch repositories: https://github.com/multiarch/ubuntu-debootstrap .

This PR's Travis CI is failed.
Because the CI has not been executed since years ago.

Here is the result on my repository.
https://travis-ci.org/junaruga/fedora/builds/528312699

```
+wget --timeout=10 -4q --spider https://download.fedoraproject.org/pub/fedora/linux/releases/24/Docker/aarch64/images
+echo 'error: Unable to find correct base url'
error: Unable to find correct base url
+exit 1
The command "./update.sh" exited with 1.
```

Fedora 24 in the log is very old. Now Fedora's latest version is 30.
Fedora 30, 29, 28 could be available versions.
https://fedoraproject.org/wiki/End_of_life

I think we can also update this repository's `update.sh` to use those versions later.
