### PR TITLE
Improve random CI failures by unstable HTTP access

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,27 @@ dist: xenial
 services:
     - docker
 language: bash
+addons:
+    apt:
+        config:
+            retries: true
+        update: true
+        sources:
+            - sourceline: 'deb http://archive.ubuntu.com/ubuntu bionic main universe'
+        packages:
+            # Install wget >= 1.19.1 to use wget --retry-on-http-error=NNN,NNN option
+            # https://lists.gnu.org/archive/html/bug-wget/2017-02/msg00065.html
+            # https://packages.ubuntu.com/bionic/wget
+            - wget
 env:
     global:
         - QEMU_VER=v3.1.0-3
         - DOCKER_SERVER=docker.io
         - DOCKER_REPO=$DOCKER_SERVER/multiarch/fedora
     matrix:
+        # Set available tar files
+        # https://download.fedoraproject.org/pub/fedora/linux/releases/$VERSION/Container/$ARCH/images
+        # https://download.fedoraproject.org/pub/fedora-secondary/releases/$VERSION/Container/$ARCH/images
         - ARCH=x86_64 QEMU_ARCH= VERSION=29
         - ARCH=aarch64 QEMU_ARCH=aarch64 VERSION=29
         - ARCH=ppc64le QEMU_ARCH=ppc64le VERSION=29

--- a/update.sh
+++ b/update.sh
@@ -22,13 +22,27 @@ mysha256sum=sha256sum
 if which gsha256sum &> /dev/null; then
 	mysha256sum=gsha256sum
 fi
+wget_common_opts="-t 3 -w 1 --retry-connrefused --no-dns-cache --retry-on-http-error=403"
+wget_opts="${wget_common_opts} -N"
+wget_spider_opts="${wget_common_opts} --spider"
+
+function wget_and_sleep() {
+	wget ${@}
+	return_code=${?}
+	sleep 1
+	return ${return_code}
+}
 
 (
 rootTar="Fedora-Container-Root-${VERSION}.${ARCH}.tar"
-baseUrl="https://download.fedoraproject.org/pub"
-if wget --timeout=10 -4q --spider "$baseUrl/fedora-secondary/releases/${VERSION}/Container/${ARCH}/images"; then
+# Use a real server dl.fedoraproject.org
+# instead of a balancing server download.fedoraproject.org
+# to avoid redirected to an invalid mirror server that causes http status 404.
+# baseUrl="https://download.fedoraproject.org/pub"
+baseUrl="https://dl.fedoraproject.org/pub"
+if wget_and_sleep ${wget_spider_opts} "$baseUrl/fedora-secondary/releases/${VERSION}/Container/${ARCH}/images"; then
 	baseUrl+="/fedora-secondary/releases/${VERSION}/Container/${ARCH}/images"
-elif wget --timeout=10 -4q --spider "$baseUrl/fedora/linux/releases/${VERSION}/Container/${ARCH}/images"; then
+elif wget_and_sleep ${wget_spider_opts} "$baseUrl/fedora/linux/releases/${VERSION}/Container/${ARCH}/images"; then
 	baseUrl+="/fedora/linux/releases/${VERSION}/Container/${ARCH}/images"
 else
 	echo >&2 "error: Unable to find correct base url"
@@ -38,7 +52,7 @@ fi
 for update in 5 4 3 2 1 0; do
 	# 30-s390x only has the Minimal-Base image.
 	for base in Base Minimal-Base; do
-		if wget -4q --timeout=10 --spider "$baseUrl/Fedora-Container-${base}-${VERSION}-1.$update.${ARCH}.tar.xz"; then
+		if wget_and_sleep ${wget_spider_opts} "$baseUrl/Fedora-Container-${base}-${VERSION}-1.$update.${ARCH}.tar.xz"; then
 			fullTar="Fedora-Container-${base}-${VERSION}-1.$update.${ARCH}.tar.xz"
 			checksum="Fedora-Container-${VERSION}-1.$update-${ARCH}-CHECKSUM"
 			break 2
@@ -53,8 +67,8 @@ fi
 
 mkdir -p ../.temp/$fullTar.temp
 pushd ../.temp
-wget -4qN "$baseUrl/$checksum" || true
-wget -4N "$baseUrl/$fullTar"
+wget_and_sleep ${wget_opts} "$baseUrl/$checksum" || true
+wget_and_sleep ${wget_opts} "$baseUrl/$fullTar"
 if [ -f $checksum ]; then
 	# Set ignore-missing to Ignore Fedora-Container-Minimal-Base-*.tar.gz
 	# in the checksum file.
@@ -76,7 +90,7 @@ EOF
 
 if [ -n "${QEMU_ARCH}" ]; then
 	if [ ! -f x86_64_qemu-${QEMU_ARCH}-static.tar.gz ]; then
-		wget -4N https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_VER}/x86_64_qemu-${QEMU_ARCH}-static.tar.gz
+		wget_and_sleep ${wget_opts} https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_VER}/x86_64_qemu-${QEMU_ARCH}-static.tar.gz
 	fi
 	cat >> Dockerfile <<EOF
 


### PR DESCRIPTION
Current Travis master has random failure.
https://travis-ci.org/multiarch/fedora/builds/528501520

Improve random CI failures by unstable HTTP access to check or download URL.

* Add wget --retry-on-http-error=403 option.
* Add retry 3 times to wget
* Use a real server dl.fedoraproject.org
  instead of a balancing server download.fedoraproject.org
  to avoid redirected to an invalid mirror server that causes http status 404.