### PR TITLE
Add armhfp (ARM 32-bit) case.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ env:
         # Set available tar files
         # https://download.fedoraproject.org/pub/fedora/linux/releases/$VERSION/Container/$ARCH/images
         # https://download.fedoraproject.org/pub/fedora-secondary/releases/$VERSION/Container/$ARCH/images
+        - ARCH=armhfp QEMU_ARCH=arm VERSION=28
+
         - ARCH=x86_64 QEMU_ARCH= VERSION=29
         - ARCH=aarch64 QEMU_ARCH=aarch64 VERSION=29
         - ARCH=ppc64le QEMU_ARCH=ppc64le VERSION=29


### PR DESCRIPTION
I found armhfp (ARM 32-bit) container image archive from Fedora 28.
Shall we add this case to CI?
It is useful as right now this repository does not have 32-bit image.

My repository's CI is success.
https://travis-ci.org/junaruga/fedora/builds/540072183

