### PR TITLE
Replace tab with 4 spaces aligning other module/*'s update.sh

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -4,33 +4,33 @@
 OPTIND=1 # Reset in case getopts has been used previously in the shell.
 
 while getopts "a:v:q:u:d:" opt; do
-	case "$opt" in
-	a)  ARCH=$OPTARG
-		;;
-	v)  VERSION=$OPTARG
-		;;
-	q)  QEMU_ARCH=$OPTARG
-		;;
-	u)  QEMU_VER=$OPTARG
-		;;
-	d)  DOCKER_REPO=$OPTARG
-		;;
-	esac
+    case "$opt" in
+    a)  ARCH=$OPTARG
+        ;;
+    v)  VERSION=$OPTARG
+        ;;
+    q)  QEMU_ARCH=$OPTARG
+        ;;
+    u)  QEMU_VER=$OPTARG
+        ;;
+    d)  DOCKER_REPO=$OPTARG
+        ;;
+    esac
 done
 
 mysha256sum=sha256sum
 if which gsha256sum &> /dev/null; then
-	mysha256sum=gsha256sum
+    mysha256sum=gsha256sum
 fi
 wget_common_opts="-t 3 -w 1 --retry-connrefused --no-dns-cache --retry-on-http-error=403"
 wget_opts="${wget_common_opts} -N"
 wget_spider_opts="${wget_common_opts} --spider"
 
 function wget_and_sleep() {
-	wget ${@}
-	return_code=${?}
-	sleep 1
-	return ${return_code}
+    wget ${@}
+    return_code=${?}
+    sleep 1
+    return ${return_code}
 }
 
 (
@@ -41,28 +41,28 @@ rootTar="Fedora-Container-Root-${VERSION}.${ARCH}.tar"
 # baseUrl="https://download.fedoraproject.org/pub"
 baseUrl="https://dl.fedoraproject.org/pub"
 if wget_and_sleep ${wget_spider_opts} "$baseUrl/fedora-secondary/releases/${VERSION}/Container/${ARCH}/images"; then
-	baseUrl+="/fedora-secondary/releases/${VERSION}/Container/${ARCH}/images"
+    baseUrl+="/fedora-secondary/releases/${VERSION}/Container/${ARCH}/images"
 elif wget_and_sleep ${wget_spider_opts} "$baseUrl/fedora/linux/releases/${VERSION}/Container/${ARCH}/images"; then
-	baseUrl+="/fedora/linux/releases/${VERSION}/Container/${ARCH}/images"
+    baseUrl+="/fedora/linux/releases/${VERSION}/Container/${ARCH}/images"
 else
-	echo >&2 "error: Unable to find correct base url"
-	exit 1
+    echo >&2 "error: Unable to find correct base url"
+    exit 1
 fi
 
 for update in 5 4 3 2 1 0; do
-	# 30-s390x only has the Minimal-Base image.
-	for base in Base Minimal-Base; do
-		if wget_and_sleep ${wget_spider_opts} "$baseUrl/Fedora-Container-${base}-${VERSION}-1.$update.${ARCH}.tar.xz"; then
-			fullTar="Fedora-Container-${base}-${VERSION}-1.$update.${ARCH}.tar.xz"
-			checksum="Fedora-Container-${VERSION}-1.$update-${ARCH}-CHECKSUM"
-			break 2
-		fi
-	done
+    # 30-s390x only has the Minimal-Base image.
+    for base in Base Minimal-Base; do
+        if wget_and_sleep ${wget_spider_opts} "$baseUrl/Fedora-Container-${base}-${VERSION}-1.$update.${ARCH}.tar.xz"; then
+            fullTar="Fedora-Container-${base}-${VERSION}-1.$update.${ARCH}.tar.xz"
+            checksum="Fedora-Container-${VERSION}-1.$update-${ARCH}-CHECKSUM"
+            break 2
+        fi
+    done
 done
 
 if [ -z "$fullTar" ]; then
-	echo >&2 "error: Unable to find correct update"
-	exit 1
+    echo >&2 "error: Unable to find correct update"
+    exit 1
 fi
 
 mkdir -p ../.temp/$fullTar.temp
@@ -70,12 +70,12 @@ pushd ../.temp
 wget_and_sleep ${wget_opts} "$baseUrl/$checksum" || true
 wget_and_sleep ${wget_opts} "$baseUrl/$fullTar"
 if [ -f $checksum ]; then
-	# Set ignore-missing to Ignore Fedora-Container-Minimal-Base-*.tar.gz
-	# in the checksum file.
-	if ! $mysha256sum --status -c --ignore-missing $checksum; then
-		echo >&2 "error: '$fullTar' has invalid SHA256"
-		exit 1
-	fi
+    # Set ignore-missing to Ignore Fedora-Container-Minimal-Base-*.tar.gz
+    # in the checksum file.
+    if ! $mysha256sum --status -c --ignore-missing $checksum; then
+        echo >&2 "error: '$fullTar' has invalid SHA256"
+        exit 1
+    fi
 fi
 popd
 tar -C ../.temp/$fullTar.temp -xf "../.temp/$fullTar"
@@ -89,10 +89,10 @@ ENV ARCH=${ARCH} FEDORA_SUITE=${VERSION} DOCKER_REPO=${DOCKER_REPO}
 EOF
 
 if [ -n "${QEMU_ARCH}" ]; then
-	if [ ! -f x86_64_qemu-${QEMU_ARCH}-static.tar.gz ]; then
-		wget_and_sleep ${wget_opts} https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_VER}/x86_64_qemu-${QEMU_ARCH}-static.tar.gz
-	fi
-	cat >> Dockerfile <<EOF
+    if [ ! -f x86_64_qemu-${QEMU_ARCH}-static.tar.gz ]; then
+        wget_and_sleep ${wget_opts} https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_VER}/x86_64_qemu-${QEMU_ARCH}-static.tar.gz
+    fi
+    cat >> Dockerfile <<EOF
 
 # Add qemu-user-static binary for amd64 builders
 ADD x86_64_qemu-${QEMU_ARCH}-static.tar.gz /usr/bin
@@ -108,10 +108,10 @@ EOF
 
 docker build -t "${DOCKER_REPO}:${VERSION}-${ARCH}" .
 docker run -it --rm "${DOCKER_REPO}:${VERSION}-${ARCH}" bash -xc '
-	uname -a
-	echo
-	cat /etc/os-release 2>/dev/null
-	echo
-	cat /etc/redhat-release 2>/dev/null
-	true
+    uname -a
+    echo
+    cat /etc/os-release 2>/dev/null
+    echo
+    cat /etc/redhat-release 2>/dev/null
+    true
 '


### PR DESCRIPTION
This PR is for refactoring.
Right now seeing "multiarch/alpine, centos, debian-debootstrap, ubuntu-debootstrap"'s `update.sh`, the indent is 4 spaces rather than tab. ("multiarch/busybox" is a mix of spaces and tab. But we can align it too in the future.)
So, I like aligning "multiarch/fedora" too.

Just replaced it by editor's replacement function.