### PR TITLE
Add test for the created images.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
             - wget
 env:
     global:
-        - QEMU_VER=v3.1.0-3
+        - QEMU_VER=v4.0.0-2
         - DOCKER_SERVER=docker.io
         - DOCKER_REPO=$DOCKER_SERVER/multiarch/fedora
     matrix:
@@ -37,8 +37,13 @@ env:
 before_install:
     - docker run --rm --privileged multiarch/qemu-user-static:register
 
+install:
+    - |
+      make ARCH="${ARCH}" VERSION="${VERSION}" QEMU_ARCH="${QEMU_ARCH}" QEMU_VER="${QEMU_VER}" DOCKER_REPO="${DOCKER_REPO}"
+
 script:
-    - ./update.sh -a "$ARCH" -v "$VERSION" -q "$QEMU_ARCH" -u "$QEMU_VER" -d "$DOCKER_REPO"
+    - |
+      make test ARCH="${ARCH}" VERSION="${VERSION}" DOCKER_REPO="${DOCKER_REPO}"
 
 after_success:
     - |

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+CWD = $(shell pwd)
+
+.PHONY: update
+update:
+	./update.sh -a "$(ARCH)" -v "$(VERSION)" -q "$(QEMU_ARCH)" -u "$(QEMU_VER)" -d "$(DOCKER_REPO)"
+
+.PHONY: test
+test:
+	docker run -t --rm -v "$(CWD):/work" -w /work "$(DOCKER_REPO):$(VERSION)-$(ARCH)" ./test.sh

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -xeo pipefail
+
+if command -v dnf > /dev/null; then
+    dnf -y update
+    dnf -y install gcc
+fi


### PR DESCRIPTION
Related to https://github.com/multiarch/fedora/issues/13  and https://github.com/multiarch/qemu-user-static/issues/72 .

I think using `Makefile` is natural in this project seeing
https://github.com/multiarch/true/blob/master/Makefile .

Good news.
With QEMU v3.1.0-3, the s390x test are failed.
As Fedora 29 s390x is a full environment with `dnf`, the test is executed and failed.
As Fedora 30 s390x is a minimal environment without `dnf` and with `microdnf`, the test is skipped. (So, succeeded)
https://travis-ci.org/multiarch/fedora/builds/543888437

With QEMU 4.0.0-2, the Fedora 29 s390x is succeeded.
https://travis-ci.org/multiarch/fedora/builds/543893920

Adding the test, the Travis running time is increased. But I think that it's worth to add it.